### PR TITLE
Update version to fit with dependent project

### DIFF
--- a/playlists.cabal
+++ b/playlists.cabal
@@ -104,7 +104,7 @@ executable playlist
 
   build-depends: base
                , bytestring
-               , optparse-applicative >= 0.10 && < 0.15
+               , optparse-applicative >= 0.10 && < 0.16
                , playlists
                , text
 

--- a/src/Text/Playlist/M3U/Writer.hs
+++ b/src/Text/Playlist/M3U/Writer.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 {-
 
@@ -16,12 +16,11 @@ the LICENSE file.
 module Text.Playlist.M3U.Writer (writePlaylist) where
 
 --------------------------------------------------------------------------------
-import Data.ByteString.Lazy.Builder (Builder)
+import           Data.ByteString.Lazy.Builder (Builder)
 import qualified Data.ByteString.Lazy.Builder as B
-import Data.Monoid
-import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
-import Text.Playlist.Types
+import           Data.Text                    (Text)
+import           Data.Text.Encoding           (encodeUtf8)
+import           Text.Playlist.Types
 
 --------------------------------------------------------------------------------
 writePlaylist :: Playlist -> Builder
@@ -46,11 +45,11 @@ writeTitleAndLength Track{..} =
 
 --------------------------------------------------------------------------------
 writeLength :: Maybe Float -> Builder
-writeLength Nothing = mempty
+writeLength Nothing  = mempty
 writeLength (Just l) = B.stringUtf8 (show l)
 
 --------------------------------------------------------------------------------
 writeTitle :: Maybe Text -> Builder
-writeTitle Nothing = mempty
+writeTitle Nothing  = mempty
 writeTitle (Just x) = B.byteString (encodeUtf8 x)
 

--- a/src/Text/Playlist/PLS/Writer.hs
+++ b/src/Text/Playlist/PLS/Writer.hs
@@ -18,11 +18,10 @@ module Text.Playlist.PLS.Writer
        ) where
 
 --------------------------------------------------------------------------------
-import Data.ByteString.Lazy.Builder (Builder)
+import           Data.ByteString.Lazy.Builder (Builder)
 import qualified Data.ByteString.Lazy.Builder as B
-import Data.Monoid
-import Data.Text.Encoding (encodeUtf8)
-import Text.Playlist.Types
+import           Data.Text.Encoding           (encodeUtf8)
+import           Text.Playlist.Types
 
 --------------------------------------------------------------------------------
 writePlaylist :: Playlist -> Builder

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.14
+resolver: lts-15.11
 
 packages:
 - ./

--- a/util/playlist.hs
+++ b/util/playlist.hs
@@ -13,12 +13,11 @@ the LICENSE file.
 module Main where
 
 --------------------------------------------------------------------------------
-import qualified Data.ByteString as BS
+import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BL
-import Data.Monoid
-import qualified Data.Text as T
-import Options.Applicative
-import Text.Playlist
+import qualified Data.Text            as T
+import           Options.Applicative
+import           Text.Playlist
 
 --------------------------------------------------------------------------------
 data Command = CmdURLs Format | CmdConvert Format Format


### PR DESCRIPTION
Add GHC-8.8 support:
- Relax `optparse-applicative` version.
- Remove `Data.Monoid` as redudant.
- Bump LTS version.