### PR TITLE
Add Types to exposed-modules

### DIFF
--- a/playlists.cabal
+++ b/playlists.cabal
@@ -66,6 +66,7 @@ flag test-doctest
 library
   exposed-modules:
     Text.Playlist
+    Text.Playlist.Types
   other-modules:
     Text.Playlist.Internal.Attoparsec
     Text.Playlist.Internal.Format
@@ -75,7 +76,6 @@ library
     Text.Playlist.M3U.Writer
     Text.Playlist.PLS.Reader
     Text.Playlist.PLS.Writer
-    Text.Playlist.Types
 
   default-language: Haskell2010
   hs-source-dirs: src


### PR DESCRIPTION
Resolve: 

```
    Could not load module ‘Text.Playlist.Types’
    it is a hidden module in the package ‘playlists-0.5.0.0’
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
```